### PR TITLE
Cleanup functions and code

### DIFF
--- a/bash_profile_switcher.sh
+++ b/bash_profile_switcher.sh
@@ -40,11 +40,11 @@ export SWITCH_PROFILE_SAVED=".bash_saved_profile"
 # snipname1:snipname2:snippetname3
 export SWITCH_PROFILE_SNIPPETS=""
 
-# _parse_profile
+# _switch_profile_parse
 # To be used with mapfile
 # Every line in the file is parsed and checked for a corresponding snippet to be loaded
 
-_parse_profile() {
+_switch_profile_parse() {
     local VALUE
     local SNIPPET
     VALUE="$2"
@@ -245,5 +245,5 @@ if [ -z ${SWITCH_PROFILE_NEXT+is_set} ]; then {
 fi
 
 if [ -n "${SWITCH_PROFILE_CURRENT+is_set}" ]; then
-    mapfile -c 1 -C _parse_profile -t <"${HOME}/${SWITCH_PROFILE_DIRECTORY}/${SWITCH_PROFILE_CURRENT}.profile"
+    mapfile -c 1 -C _switch_profile_parse -t <"${HOME}/${SWITCH_PROFILE_DIRECTORY}/${SWITCH_PROFILE_CURRENT}.profile"
 fi

--- a/bash_profile_switcher.sh
+++ b/bash_profile_switcher.sh
@@ -40,9 +40,6 @@ export SWITCH_PROFILE_SAVED=".bash_saved_profile"
 # snipname1:snipname2:snippetname3
 export SWITCH_PROFILE_SNIPPETS=""
 
-# Setup aliases to manage profiles
-alias _save_bash_profile='eval echo "export SWITCH_PROFILE_CURRENT=$SELECTED_PROFILE" > "$HOME/$SWITCH_PROFILE_SAVED"'
-
 # _parse_profile
 # To be used with mapfile
 # Every line in the file is parsed and checked for a corresponding snippet to be loaded
@@ -213,7 +210,11 @@ switch_profile() {
 
     SELECTED_PROFILE="$1"
     if [ -f "${HOME}/${SWITCH_PROFILE_DIRECTORY}/${SELECTED_PROFILE}.profile" ]; then {
-        if [ $TEMP_PROFILE -eq 0 ]; then _save_bash_profile; else export SWITCH_PROFILE_NEXT="$SELECTED_PROFILE"; fi
+        if [ $TEMP_PROFILE -eq 0 ]; then
+            echo "export SWITCH_PROFILE_CURRENT=$SELECTED_PROFILE" >"$HOME/$SWITCH_PROFILE_SAVED"
+        else
+            export SWITCH_PROFILE_NEXT="$SELECTED_PROFILE"
+        fi
         exec bash
     }; else
         {

--- a/bash_profile_switcher.sh
+++ b/bash_profile_switcher.sh
@@ -164,7 +164,7 @@ EOF
 
 switch_profile() {
     local OPTIND OPTARG SELECTED_PROFILE KEEP_ENV TEMP_PROFILE RESET_PROFILE
-
+    local -a SNIPPET_ARRAY
     KEEP_ENV=0
     TEMP_PROFILE=0
     RESET_PROFILE=0
@@ -199,11 +199,11 @@ switch_profile() {
     shift $((OPTIND - 1))
 
     if ! [ $KEEP_ENV -eq 1 ]; then
-        #[ -f "$HOME/$SWITCH_PROFILE_DIRECTORY/snippets/$SNIPPET.sh" ]
-        for ((n = -1; n >= -${#LOAD_SNIPPETS[*]}; n--)); do
-            if _snippet search "$(basename "${LOAD_SNIPPETS[$n]}" .sh)"; then
+        IFS=':' read -r -a SNIPPET_ARRAY <<<"$SWITCH_PROFILE_SNIPPETS"
+        for ((n = -1; n >= -${#SNIPPET_ARRAY[*]}; n--)); do
+            if [ -f "$HOME/$SWITCH_PROFILE_DIRECTORY/snippets/${SNIPPET_ARRAY[$n]}.sh" ]; then
                 # shellcheck source=/dev/null
-                source "${LOAD_SNIPPETS[$n]}" unload && _snippet pop "$(basename "${LOAD_SNIPPETS[$n]}" .sh)"
+                source "$HOME/$SWITCH_PROFILE_DIRECTORY/snippets/${SNIPPET_ARRAY[$n]}.sh" unload && _snippet pop "${SNIPPET_ARRAY[$n]}"
             fi
         done
     fi

--- a/bash_profile_switcher.sh
+++ b/bash_profile_switcher.sh
@@ -43,7 +43,7 @@ export SWITCH_PROFILE_SNIPPETS=""
 # _parse_profile
 # To be used with mapfile
 # Every line in the file is parsed and checked for a corresponding snippet to be loaded
-# It will store the valid snippets in global array LOAD_SNIPPETS
+
 _parse_profile() {
     local VALUE
     local SNIPPET

--- a/bash_profile_switcher.sh
+++ b/bash_profile_switcher.sh
@@ -169,7 +169,7 @@ switch_profile() {
 
     KEEP_ENV=0
     TEMP_PROFILE=0
-    while getopts "tkdhl" Option; do
+    while getopts ":tkdhl" Option; do
         case $Option in
         k)
             KEEP_ENV=1

--- a/bash_profile_switcher.sh
+++ b/bash_profile_switcher.sh
@@ -225,13 +225,13 @@ if [ -z ${SWITCH_PROFILE_NEXT+is_set} ]; then {
         {
             # shellcheck source=/dev/null
             source "$HOME/$SWITCH_PROFILE_SAVED"
-            if [ -n "${SWITCH_PROFILE_CURRENT+is_set}" ]; then _load_bash_profile; fi
         }
     fi
 }; else
     {
         export SWITCH_PROFILE_CURRENT="$SWITCH_PROFILE_NEXT"
         unset SWITCH_PROFILE_NEXT
-        _load_bash_profile
     }
 fi
+
+if [ -n "${SWITCH_PROFILE_CURRENT+is_set}" ]; then _load_bash_profile; fi


### PR DESCRIPTION
- remove aliases using `eval` and use directly functions or executable calls
- remove internal usage of LOAD_SNIPPETS array
- rename internal functions