### PR TITLE
rework internal code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SNIPPETS_DIRECTORY := $(PROFILE_DIRECTORY)/snippets
 PACKAGE_NAME := bash-profile-switcher
 PACKAGE_FILES := README.md Makefile bash_profile_switcher.sh snippets .version
 REF_TYPE := $(GITHUB_REF_TYPE)
-VERSION := $(shell git log -n1 --pretty=format:%h)
+VERSION := $(shell git log -n1 --pretty=format:%h 2> /dev/null || echo dev)
 ifeq ("$(REF_TYPE)","branch")
         VERSION := $(GITHUB_SHA)
 endif

--- a/bash_profile_switcher.sh
+++ b/bash_profile_switcher.sh
@@ -42,32 +42,32 @@ export SWITCH_PROFILE_SNIPPETS=""
 
 # shellcheck source=/dev/null
 [[ -f "$HOME/$SWITCH_PROFILE_DIRECTORY/.version" ]] && source "$HOME/$SWITCH_PROFILE_DIRECTORY/.version"
-# _switch_profile_parse
+# __switch_profile_parse
 # To be used with mapfile
 # Every line in the file is parsed and checked for a corresponding snippet to be loaded
 
-_switch_profile_parse() {
+__switch_profile_parse() {
     local VALUE
     local SNIPPET
     VALUE="$2"
     if [[ "$VALUE" =~ ^[[:blank:]]*([^# ]+)([[:blank:]]|$) ]]; then
         {
             SNIPPET="${BASH_REMATCH[1]}"
-            if [ -f "$HOME/$SWITCH_PROFILE_DIRECTORY/snippets/$SNIPPET.sh" ] && ! _switch_profile_snippet search "$SNIPPET"; then
+            if [ -f "$HOME/$SWITCH_PROFILE_DIRECTORY/snippets/$SNIPPET.sh" ] && ! __switch_profile_snippet search "$SNIPPET"; then
                 # shellcheck source=/dev/null
-                source "$HOME/$SWITCH_PROFILE_DIRECTORY/snippets/$SNIPPET.sh" load && _switch_profile_snippet push "$SNIPPET"
+                source "$HOME/$SWITCH_PROFILE_DIRECTORY/snippets/$SNIPPET.sh" load && __switch_profile_snippet push "$SNIPPET"
             fi
         }
     fi
     return 0
 }
 
-# _switch_profile_snippet [push|pop|search] <snippet name>
+# __switch_profile_snippet [push|pop|search] <snippet name>
 # Manage the status of snippets storing it in SWITCH_PROFILE_SNIPPETS if it has loaded or unloaded.
 # - push the snippet name into SWITCH_PROFILE_SNIPPETS only if the value is not already present
 # - pop the snippet name from SWITCH_PROFILE_SNIPPETS
 # - search if a snippet name is present in SWITCH_PROFILE_SNIPPETS
-_switch_profile_snippet() {
+__switch_profile_snippet() {
     local -r snippet_cmd="${1:-}"
     local -r snippet_name="${2:-}"
     local -r REGEX="(^|.*:)(${snippet_name})(:.*|$)"
@@ -93,7 +93,7 @@ _switch_profile_snippet() {
 }
 
 # Create list of profiles from .profile files
-_switch_profile_list() {
+__switch_profile_list() {
     local PROFILE_LIST
     # Note: If there are no matching files, echo *.profile output literally "*.profile"
     PROFILE_LIST="$(echo "$HOME/$SWITCH_PROFILE_DIRECTORY/"*.profile)"
@@ -103,11 +103,11 @@ _switch_profile_list() {
     echo "$PROFILE_LIST"
 }
 
-SWITCH_PROFILE_LIST=$(_switch_profile_list)
+SWITCH_PROFILE_LIST=$(__switch_profile_list)
 export SWITCH_PROFILE_LIST
 
 ### FUNCTION DECLARATION ###
-_switch_profile_help() {
+__switch_profile_help() {
     cat <<EOF
 switch_profile [options] profile
 
@@ -177,14 +177,14 @@ switch_profile() {
             TEMP_PROFILE=1
             ;;
         l)
-            SWITCH_PROFILE_LIST=$(_switch_profile_list)
+            SWITCH_PROFILE_LIST=$(__switch_profile_list)
             export SWITCH_PROFILE_LIST
             [ -n "$SWITCH_PROFILE_LIST" ] && complete -o nospace -W "$SWITCH_PROFILE_LIST" switch_profile
             echo -e "${SWITCH_PROFILE_LIST// /\\n}"
             return 0
             ;;
         h)
-            _switch_profile_help
+            __switch_profile_help
             return 0
             ;;
         v)
@@ -195,7 +195,7 @@ switch_profile() {
             RESET_PROFILE=1
             ;;
         *)
-            _switch_profile_help
+            __switch_profile_help
             return 1
             ;;
         esac
@@ -207,7 +207,7 @@ switch_profile() {
         for ((n = -1; n >= -${#SNIPPET_ARRAY[*]}; n--)); do
             if [ -f "$HOME/$SWITCH_PROFILE_DIRECTORY/snippets/${SNIPPET_ARRAY[$n]}.sh" ]; then
                 # shellcheck source=/dev/null
-                source "$HOME/$SWITCH_PROFILE_DIRECTORY/snippets/${SNIPPET_ARRAY[$n]}.sh" unload && _switch_profile_snippet pop "${SNIPPET_ARRAY[$n]}"
+                source "$HOME/$SWITCH_PROFILE_DIRECTORY/snippets/${SNIPPET_ARRAY[$n]}.sh" unload && __switch_profile_snippet pop "${SNIPPET_ARRAY[$n]}"
             fi
         done
     fi
@@ -226,7 +226,7 @@ switch_profile() {
         exec bash
     }; else
         {
-            _switch_profile_help
+            __switch_profile_help
             echo "Selected profile does not exist."
             switch_profile -l
             echo ""
@@ -253,5 +253,5 @@ if [ -z ${SWITCH_PROFILE_NEXT+is_set} ]; then {
 fi
 
 if [ -n "${SWITCH_PROFILE_CURRENT+is_set}" ]; then
-    mapfile -c 1 -C _switch_profile_parse -t <"${HOME}/${SWITCH_PROFILE_DIRECTORY}/${SWITCH_PROFILE_CURRENT}.profile"
+    mapfile -c 1 -C __switch_profile_parse -t <"${HOME}/${SWITCH_PROFILE_DIRECTORY}/${SWITCH_PROFILE_CURRENT}.profile"
 fi

--- a/bash_profile_switcher.sh
+++ b/bash_profile_switcher.sh
@@ -53,21 +53,21 @@ _switch_profile_parse() {
     if [[ "$VALUE" =~ ^[[:blank:]]*([^# ]+)([[:blank:]]|$) ]]; then
         {
             SNIPPET="${BASH_REMATCH[1]}"
-            if [ -f "$HOME/$SWITCH_PROFILE_DIRECTORY/snippets/$SNIPPET.sh" ] && ! _snippet search "$SNIPPET"; then
+            if [ -f "$HOME/$SWITCH_PROFILE_DIRECTORY/snippets/$SNIPPET.sh" ] && ! _switch_profile_snippet search "$SNIPPET"; then
                 # shellcheck source=/dev/null
-                source "$HOME/$SWITCH_PROFILE_DIRECTORY/snippets/$SNIPPET.sh" load && _snippet push "$SNIPPET"
+                source "$HOME/$SWITCH_PROFILE_DIRECTORY/snippets/$SNIPPET.sh" load && _switch_profile_snippet push "$SNIPPET"
             fi
         }
     fi
     return 0
 }
 
-# _snippet [push|pop|search] <snippet name>
+# _switch_profile_snippet [push|pop|search] <snippet name>
 # Manage the status of snippets storing it in SWITCH_PROFILE_SNIPPETS if it has loaded or unloaded.
 # - push the snippet name into SWITCH_PROFILE_SNIPPETS only if the value is not already present
 # - pop the snippet name from SWITCH_PROFILE_SNIPPETS
 # - search if a snippet name is present in SWITCH_PROFILE_SNIPPETS
-_snippet() {
+_switch_profile_snippet() {
     local -r snippet_cmd="${1:-}"
     local -r snippet_name="${2:-}"
     local -r REGEX="(^|.*:)(${snippet_name})(:.*|$)"
@@ -207,7 +207,7 @@ switch_profile() {
         for ((n = -1; n >= -${#SNIPPET_ARRAY[*]}; n--)); do
             if [ -f "$HOME/$SWITCH_PROFILE_DIRECTORY/snippets/${SNIPPET_ARRAY[$n]}.sh" ]; then
                 # shellcheck source=/dev/null
-                source "$HOME/$SWITCH_PROFILE_DIRECTORY/snippets/${SNIPPET_ARRAY[$n]}.sh" unload && _snippet pop "${SNIPPET_ARRAY[$n]}"
+                source "$HOME/$SWITCH_PROFILE_DIRECTORY/snippets/${SNIPPET_ARRAY[$n]}.sh" unload && _switch_profile_snippet pop "${SNIPPET_ARRAY[$n]}"
             fi
         done
     fi

--- a/bash_profile_switcher.sh
+++ b/bash_profile_switcher.sh
@@ -30,8 +30,8 @@
 
 # Setup default directory
 export SWITCH_PROFILE_DIRECTORY=".bash_profile.d"
-[ -d "$HOME/$SWITCH_PROFILE_DIRECTORY" ] || mkdir "$HOME/$SWITCH_PROFILE_DIRECTORY"
-[ -d "$HOME/$SWITCH_PROFILE_DIRECTORY/snippets" ] || mkdir "$HOME/$SWITCH_PROFILE_DIRECTORY/snippets"
+[[ -d "$HOME/$SWITCH_PROFILE_DIRECTORY" ]] || mkdir "$HOME/$SWITCH_PROFILE_DIRECTORY"
+[[ -d "$HOME/$SWITCH_PROFILE_DIRECTORY/snippets" ]] || mkdir "$HOME/$SWITCH_PROFILE_DIRECTORY/snippets"
 
 # Setup save profile filename
 export SWITCH_PROFILE_SAVED=".bash_saved_profile"
@@ -42,6 +42,9 @@ export SWITCH_PROFILE_SNIPPETS=""
 
 # shellcheck source=/dev/null
 [[ -f "$HOME/$SWITCH_PROFILE_DIRECTORY/.version" ]] && source "$HOME/$SWITCH_PROFILE_DIRECTORY/.version"
+
+### FUNCTION DECLARATION ###
+
 # __switch_profile_parse
 # To be used with mapfile
 # Every line in the file is parsed and checked for a corresponding snippet to be loaded
@@ -53,7 +56,7 @@ __switch_profile_parse() {
     if [[ "$VALUE" =~ ^[[:blank:]]*([^# ]+)([[:blank:]]|$) ]]; then
         {
             SNIPPET="${BASH_REMATCH[1]}"
-            if [ -f "$HOME/$SWITCH_PROFILE_DIRECTORY/snippets/$SNIPPET.sh" ] && ! __switch_profile_snippet search "$SNIPPET"; then
+            if [[ -f "$HOME/$SWITCH_PROFILE_DIRECTORY/snippets/$SNIPPET.sh" ]] && ! __switch_profile_snippet search "$SNIPPET"; then
                 # shellcheck source=/dev/null
                 source "$HOME/$SWITCH_PROFILE_DIRECTORY/snippets/$SNIPPET.sh" load && __switch_profile_snippet push "$SNIPPET"
             fi
@@ -99,14 +102,13 @@ __switch_profile_list() {
     PROFILE_LIST="$(echo "$HOME/$SWITCH_PROFILE_DIRECTORY/"*.profile)"
     PROFILE_LIST="${PROFILE_LIST//$HOME\/$SWITCH_PROFILE_DIRECTORY\//}"
     PROFILE_LIST="${PROFILE_LIST//.profile/}"
-    [ "$PROFILE_LIST" = '*' ] && PROFILE_LIST=""
+    [[ "$PROFILE_LIST" = '*' ]] && PROFILE_LIST=""
     echo "$PROFILE_LIST"
 }
 
 SWITCH_PROFILE_LIST=$(__switch_profile_list)
 export SWITCH_PROFILE_LIST
 
-### FUNCTION DECLARATION ###
 __switch_profile_help() {
     cat <<EOF
 switch_profile [options] profile
@@ -179,7 +181,7 @@ switch_profile() {
         l)
             SWITCH_PROFILE_LIST=$(__switch_profile_list)
             export SWITCH_PROFILE_LIST
-            [ -n "$SWITCH_PROFILE_LIST" ] && complete -o nospace -W "$SWITCH_PROFILE_LIST" switch_profile
+            [[ -n "$SWITCH_PROFILE_LIST" ]] && complete -o nospace -W "$SWITCH_PROFILE_LIST" switch_profile
             echo -e "${SWITCH_PROFILE_LIST// /\\n}"
             return 0
             ;;
@@ -202,23 +204,23 @@ switch_profile() {
     done
     shift $((OPTIND - 1))
 
-    if ! [ $KEEP_ENV -eq 1 ]; then
+    if ! [[ $KEEP_ENV -eq 1 ]]; then
         IFS=':' read -r -a SNIPPET_ARRAY <<<"$SWITCH_PROFILE_SNIPPETS"
         for ((n = -1; n >= -${#SNIPPET_ARRAY[*]}; n--)); do
-            if [ -f "$HOME/$SWITCH_PROFILE_DIRECTORY/snippets/${SNIPPET_ARRAY[$n]}.sh" ]; then
+            if [[ -f "$HOME/$SWITCH_PROFILE_DIRECTORY/snippets/${SNIPPET_ARRAY[$n]}.sh" ]]; then
                 # shellcheck source=/dev/null
                 source "$HOME/$SWITCH_PROFILE_DIRECTORY/snippets/${SNIPPET_ARRAY[$n]}.sh" unload && __switch_profile_snippet pop "${SNIPPET_ARRAY[$n]}"
             fi
         done
     fi
-    if [ $RESET_PROFILE -eq 1 ]; then
+    if [[ $RESET_PROFILE -eq 1 ]]; then
         echo "unset SWITCH_PROFILE_CURRENT" >"$HOME/$SWITCH_PROFILE_SAVED"
         exec bash
     fi
 
     SELECTED_PROFILE="$1"
-    if [ -f "${HOME}/${SWITCH_PROFILE_DIRECTORY}/${SELECTED_PROFILE}.profile" ]; then {
-        if [ $TEMP_PROFILE -eq 0 ]; then
+    if [[ -f "${HOME}/${SWITCH_PROFILE_DIRECTORY}/${SELECTED_PROFILE}.profile" ]]; then {
+        if [[ $TEMP_PROFILE -eq 0 ]]; then
             echo "export SWITCH_PROFILE_CURRENT=$SELECTED_PROFILE" >"$HOME/$SWITCH_PROFILE_SAVED"
         else
             export SWITCH_PROFILE_NEXT="$SELECTED_PROFILE"
@@ -236,10 +238,10 @@ switch_profile() {
 }
 
 ### MAIN SCRIPT ###
-[ -n "$SWITCH_PROFILE_LIST" ] && complete -o nospace -W "$SWITCH_PROFILE_LIST" switch_profile
+[[ -n "$SWITCH_PROFILE_LIST" ]] && complete -o nospace -W "$SWITCH_PROFILE_LIST" switch_profile
 
-if [ -z ${SWITCH_PROFILE_NEXT+is_set} ]; then {
-    if [ -f "$HOME/$SWITCH_PROFILE_SAVED" ]; then
+if [[ -z ${SWITCH_PROFILE_NEXT+is_set} ]]; then {
+    if [[ -f "$HOME/$SWITCH_PROFILE_SAVED" ]]; then
         {
             # shellcheck source=/dev/null
             source "$HOME/$SWITCH_PROFILE_SAVED"
@@ -252,6 +254,6 @@ if [ -z ${SWITCH_PROFILE_NEXT+is_set} ]; then {
     }
 fi
 
-if [ -n "${SWITCH_PROFILE_CURRENT+is_set}" ]; then
+if [[ -n "${SWITCH_PROFILE_CURRENT+is_set}" ]]; then
     mapfile -c 1 -C __switch_profile_parse -t <"${HOME}/${SWITCH_PROFILE_DIRECTORY}/${SWITCH_PROFILE_CURRENT}.profile"
 fi

--- a/bash_profile_switcher.sh
+++ b/bash_profile_switcher.sh
@@ -11,7 +11,7 @@
 #
 # Source repository: https://github.com/gianluca-mascolo/bash-profile-switcher
 #
-# Copyright (C) 2022 Gianluca Mascolo
+# Copyright (C) 2022-2023 Gianluca Mascolo
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -36,8 +36,7 @@ export SWITCH_PROFILE_DIRECTORY=".bash_profile.d"
 # Setup save profile filename
 export SWITCH_PROFILE_SAVED=".bash_saved_profile"
 
-# List of loaded snippets separated by colon like
-# snipname1:snipname2:snippetname3
+# List of loaded snippets separated by colon
 export SWITCH_PROFILE_SNIPPETS=""
 
 # shellcheck source=/dev/null


### PR DESCRIPTION
- internal functions are now all prefixed with `__switch_profile_`
- use bash comparison operators
